### PR TITLE
Correción cierre de navegador

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ scraping = Crawler("Codeina")
 lista = scraping.get_list_references()
 
 #Ventaja tarda menos no tiene que comprobar todos los resultados con este metodo
-#numero = scraping.get_amount_results()
+numero = scraping.get_amount_results()
 
-#print(numero)
+print(numero)
 print(lista)

--- a/src/cima/crawler.py
+++ b/src/cima/crawler.py
@@ -72,6 +72,13 @@ class Crawler:
         for reg in registers:
             registers_list.append(reg.text.split(": ")[1])
 
-        self._browser.close()
+
 
         return registers_list
+
+    def __del__(self):
+        """
+        When the object is deleted, the destructor closes the web navigator.
+        """
+        self._browser.close()
+


### PR DESCRIPTION
Se pasa la función que cierra el navegador al método __del__(self) de la clase Crawler, con ello se puede usar el método get_amount_results() y get_list_references() del objeto sin problemas por que se cierre el navegador antes de llamarse.